### PR TITLE
draft si_gravity.R

### DIFF
--- a/R/si_gravity.R
+++ b/R/si_gravity.R
@@ -1,0 +1,27 @@
+si_gravity <- function(O_i, D_j, C_ij, flows, data,
+                       mu = 1, alpha = 1, beta = -1){
+  
+  data = data %>% 
+    dplyr::mutate(
+      # Sum all flows from Origins to Destinations
+      total_flows = sum({{flows}}),
+      
+      # Influence of scaling parameters on model variables
+      Oi_mu = {{O_i}}^mu,
+      Dj_alpha = {{D_j}}^alpha,
+      Cij_beta = {{C_ij}}^beta,
+      
+      # Calculate unscaled flows Tij
+      T_ij = Oi_mu * Dj_alpha * Cij_beta,
+      
+      # Calculate constrain parameter k
+      k = total_flows / sum(T_ij),
+      
+      # Calculate flows based on total unconstrained model
+      T_ij = T_ij * k)
+  
+  return(data %>% dplyr::select(-c(Oi_mu, Dj_alpha, Cij_beta, k, total_flows)))
+  
+  
+  
+}


### PR DESCRIPTION
Hello @Robinlovelace , @adamdennett, @Nowosad,

I've had a look at #26  and here's a draft version of how I approached it. I was hoping to get your thoughts on the following:

- The function's dependency on dplyr
- Whether a poisson model should be included to calibrate $\mu$, $\alpha$, $\beta$. Probably do this when a user doesn't provide values for these arguments?

Thank you!

Here is the function in action:

``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
source("https://raw.githubusercontent.com/R-icntay/simodels/main/R/si_gravity.R")

# Import data
mdatasub <- read.csv("https://raw.githubusercontent.com/R-icntay/sim_australia/main/mdatasub.csv")

# Run a classic gravity model
mdatasub = si_gravity(
  O_i = vi1_origpop,
  D_j = wj3_destmedinc, 
  C_ij = dist,
  flows = Flow,
  data = mdatasub,
  beta = -2
) %>% 
  mutate(T_ij = round(T_ij))

# View estimated flows T_ij
mdatasub %>% 
  glimpse()
#> Rows: 210
#> Columns: 18
#> $ Origin            <chr> "Greater Sydney", "Greater Sydney", "Greater Sydney"~
#> $ Orig_code         <chr> "1GSYD", "1GSYD", "1GSYD", "1GSYD", "1GSYD", "1GSYD"~
#> $ Destination       <chr> "Rest of NSW", "Greater Melbourne", "Rest of Vic", "~
#> $ Dest_code         <chr> "1RNSW", "2GMEL", "2RVIC", "3GBRI", "3RQLD", "4GADE"~
#> $ Flow              <int> 91031, 22601, 4416, 22888, 27445, 5817, 795, 10574, ~
#> $ vi1_origpop       <int> 4391673, 4391673, 4391673, 4391673, 4391673, 4391673~
#> $ wj1_destpop       <int> 2512952, 3999981, 1345717, 2065998, 2253723, 1225235~
#> $ vi2_origunemp     <dbl> 5.74, 5.74, 5.74, 5.74, 5.74, 5.74, 5.74, 5.74, 5.74~
#> $ wj2_destunemp     <dbl> 6.12, 5.47, 5.17, 5.86, 6.22, 5.78, 5.45, 4.76, 4.42~
#> $ vi3_origmedinc    <dbl> 780.64, 780.64, 780.64, 780.64, 780.64, 780.64, 780.~
#> $ wj3_destmedinc    <dbl> 509.97, 407.95, 506.58, 767.08, 446.48, 445.53, 522.~
#> $ vi4_origpctrent   <dbl> 31.77, 31.77, 31.77, 31.77, 31.77, 31.77, 31.77, 31.~
#> $ wj4_destpctrent   <dbl> 27.20, 27.34, 24.08, 33.19, 32.57, 28.27, 26.17, 27.~
#> $ flow_no_intra     <int> 91031, 22601, 4416, 22888, 27445, 5817, 795, 10574, ~
#> $ offset            <int> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1~
#> $ dist              <dbl> 391.4379, 682.7450, 685.8484, 707.9081, 1386.4854, 1~
#> $ unconstrainedEst1 <int> 45500, 11964, 14723, 20926, 3175, 4923, 3342, 960, 1~
#> $ T_ij              <dbl> 45500, 11964, 14723, 20926, 3175, 4923, 3342, 960, 1~
```

<sup>Created on 2022-08-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

